### PR TITLE
added identification to url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 A nice, easy script to automate cleanup after a mass-copy bank transfer in NationStates Cards. This script goes through a given list of puppets and gifts any copies of the given transfer card back to your main nation, so you don't have to do it manually!
 
 ### Usage Information:
-Install the script into a userscript manager of your choice; this can be achieved very easily by simply clicking the "raw" button while looking at the file's github page. Currently, the script has been tested only in Greasemonkey, but support for the other monkeys is planned.
+Install the script into a userscript manager of your choice; this can be achieved very easily by simply clicking the "raw" button while looking at the file's github page. Currently, the script has been fully tested only in Greasemonkey, but the other 'monkey userscript managers have been lightly tested and should work.
 
 Once you've done that, you should see a "Cleanup" link in the banner of your standard gameside NS pages. Clicking this link will take you to the transfer-cleanup page where you can enter the relevant details (or upload files containing the relevant details).
 
-From there, the script proceeds much like nslogin-web or goldretriever-web, except that it runs as a userscript on NS pages instead of a github-hosted domain. This lets us disregard the rare occurrences of preflight CORS requests (effectively doubling the program runtime) that come when you make API requests from a non-NS website.
+From there, the script proceeds much like nslogin-web or goldretriever-web, except that it runs as a userscript on NS pages instead of a github-hosted domain. This lets us disregard the occurrence of preflight CORS requests (which would otherwise double the program runtime) that come when you make API requests from a non-NS website.
 
 ### Disclaimer:
 This script *requires* you to input the passwords for your nations. That's how the NS API can verify that it's really you who wants to gift the cards. All the required code is open-source. (which is just the one userscript file!) I cannot see or access any data you input in any way shape or form. Your passwords are only stored locally on your computer if you create a file - which you have to do manually - and only get transmitted to the NS API.

--- a/transfer-cleanup.user.js
+++ b/transfer-cleanup.user.js
@@ -3,7 +3,7 @@
 // @author          SherpDaWerp
 // @description     ns-transfer-cleanup reloaded
 // @downloadURL     https://github.com/sherpdawerp/ns-transfer-cleanup/raw/master/transfer-cleanup.user.js
-// @version         1
+// @version         1.0.1
 // @match           https://www.nationstates.net/*
 // @grant           console.log
 // @run-at          document-end

--- a/transfer-cleanup.user.js
+++ b/transfer-cleanup.user.js
@@ -120,7 +120,7 @@ function logMessageToRunPage(message) {
 }
 
 async function transferCleanupCardOwnersRequest(cardInfo, useragent) {
-    let response = await fetch("https://www.nationstates.net/cgi-bin/api.cgi?q=card+owners&cardid="+cardInfo[0]+"&season="+cardInfo[1], {
+    let response = await fetch("https://www.nationstates.net/cgi-bin/api.cgi?q=card+owners&cardid="+cardInfo[0]+"&season="+cardInfo[1]+"&script=transfer-cleanup-sherpdawerp", {
         method: "GET",
         headers: {
             "User-Agent": "Transfer-Cleanup userscript/tool, developed by SherpDaWerp, in use by "+useragent,
@@ -180,7 +180,7 @@ async function transferCleanupDoGiftCard(cardInfo, credentials, toNation, lastCr
         }
     }
 
-    let response = await fetch("https://www.nationstates.net/cgi-bin/api.cgi?nation="+credentials[0]+"&c=giftcard&cardid="+cardInfo[0]+"&season="+cardInfo[1]+"&to="+toNation+"&mode=prepare", {
+    let response = await fetch("https://www.nationstates.net/cgi-bin/api.cgi?nation="+credentials[0]+"&c=giftcard&cardid="+cardInfo[0]+"&season="+cardInfo[1]+"&to="+toNation+"&mode=prepare&script=transfer-cleanup-sherpdawerp", {
         method: "GET",
         headers: reqHeaders
     });
@@ -215,7 +215,7 @@ async function transferCleanupDoGiftCard(cardInfo, credentials, toNation, lastCr
         }
     }
 
-    response = await fetch("https://www.nationstates.net/cgi-bin/api.cgi?nation="+credentials[0]+"&c=giftcard&cardid="+cardInfo[0]+"&season="+cardInfo[1]+"&to="+toNation+"&mode=execute&token="+giftToken, {
+    response = await fetch("https://www.nationstates.net/cgi-bin/api.cgi?nation="+credentials[0]+"&c=giftcard&cardid="+cardInfo[0]+"&season="+cardInfo[1]+"&to="+toNation+"&mode=execute&token="+giftToken+"&script=transfer-cleanup-sherpdawerp", {
         method: "GET",
         headers: reqHeaders
     });


### PR DESCRIPTION
JS running on Chrome is unable to set its' user-agent when making fetch requests. This adds `&script=transfer-cleanup-sherpdawerp` to all API requests in an effort to identify the script to NS when running on Chrome.

Note that "standard" (non-API) requests are unaffected as they already identify themselves via `/x-transfer-cleanup=main` or `x-transfer-cleanup=run`.